### PR TITLE
sidecar: kubelet: don't bother killing pods when non-sidecars are done

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -477,21 +477,9 @@ func (m *kubeGenericRuntimeManager) computePodActions(pod *v1.Pod, podStatus *ku
 		}
 	}
 
-	// Determine if there are any non sidecar containers that are running or need restarting
-	// if there are none, we can kill the remaining sidecars
-	sidecarsOnly := true
-	for _, container := range pod.Spec.Containers {
-		containerStatus := podStatus.FindContainerStatusByName(container.Name)
-		if !isSidecar(pod, container.Name) {
-			if kubecontainer.ShouldContainerBeRestarted(&container, pod, podStatus) || (containerStatus != nil && containerStatus.State == kubecontainer.ContainerStateRunning) {
-				sidecarsOnly = false
-			}
-		}
-	}
-
 	// determine sidecar status
 	sidecarStatus := status.GetSidecarsStatus(pod)
-	glog.Infof("Pod: %s, sidecars: %s, status: Present=%v,Ready=%v,ContainerWaiting=%v", format.Pod(pod), sidecarNames, sidecarStatus.SidecarsPresent, sidecarStatus.SidecarsReady, sidecarStatus.ContainersWaiting)
+	glog.Infof("Pod: %s, sidecars: %s, status: Present=%v,Ready=%v,ContainersWaiting=%v", format.Pod(pod), sidecarNames, sidecarStatus.SidecarsPresent, sidecarStatus.SidecarsReady, sidecarStatus.ContainersWaiting)
 
 	// If we need to (re-)create the pod sandbox, everything will need to be
 	// killed and recreated, and init containers should be purged.
@@ -574,10 +562,6 @@ func (m *kubeGenericRuntimeManager) computePodActions(pod *v1.Pod, podStatus *ku
 		// If container does not exist, or is not running, check whether we
 		// need to restart it.
 		if containerStatus == nil || containerStatus.State != kubecontainer.ContainerStateRunning {
-			if sidecarsOnly && isSidecar(pod, container.Name) {
-				glog.Infof("Pod: %s: %s: is sidecar, sidecars only, so not restarting", format.Pod(pod), container.Name)
-				continue
-			}
 			if kubecontainer.ShouldContainerBeRestarted(&container, pod, podStatus) {
 				message := fmt.Sprintf("%s: Container %+v is dead, but RestartPolicy says that we should restart it.", pod.Name, container)
 				glog.V(3).Infof(message)
@@ -593,17 +577,6 @@ func (m *kubeGenericRuntimeManager) computePodActions(pod *v1.Pod, podStatus *ku
 			// Restart regardless of the restart policy because the container
 			// spec changed.
 			restart = true
-		} else if sidecarsOnly && isSidecar(pod, container.Name) {
-			// in this case, the container is a sidecar, but no
-			// non-sidecars are ever going to run again. we don't need
-			// the sidecars, so we kill it as well
-			reason = "Non-sidecars have completed. Container will be killed."
-			// we are not planning to restart this container.
-			restart = false
-			// keepCount set to avoid killing pod right away - we should only
-			// kill pod once all containers have exited and we get back into this
-			// loop.
-			keepCount += 1
 		} else if liveness, found := m.livenessManager.Get(containerStatus.ID); found && liveness == proberesults.Failure {
 			// If the container failed the liveness probe, we should kill it.
 			reason = "Container failed liveness probe."

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -1096,67 +1096,6 @@ func TestComputePodActionsWithSidecar(t *testing.T) {
 		mutateStatusFn func(*kubecontainer.PodStatus)
 		actions        podActions
 	}{
-		"Kill sidecars if all non-sidecars are terminated": {
-			mutatePodFn: func(pod *v1.Pod) {
-				pod.Spec.RestartPolicy = v1.RestartPolicyOnFailure
-			},
-			mutateStatusFn: func(status *kubecontainer.PodStatus) {
-				for i := range status.ContainerStatuses {
-					if i == 1 {
-						continue
-					}
-					status.ContainerStatuses[i].State = kubecontainer.ContainerStateExited
-					status.ContainerStatuses[i].ExitCode = 0
-				}
-			},
-			actions: podActions{
-				SandboxID:         baseStatus.SandboxStatuses[0].Id,
-				ContainersToKill:  getKillMap(basePod, baseStatus, []int{1}),
-				ContainersToStart: []int{},
-			},
-		},
-		"Kill pod if all sidecars and non-sidecars are terminated": {
-			mutatePodFn: func(pod *v1.Pod) {
-				pod.Spec.RestartPolicy = v1.RestartPolicyOnFailure
-			},
-			mutateStatusFn: func(status *kubecontainer.PodStatus) {
-				for i := range status.ContainerStatuses {
-					status.ContainerStatuses[i].State = kubecontainer.ContainerStateExited
-					if i == 1 {
-						status.ContainerStatuses[i].ExitCode = 1
-					} else {
-						status.ContainerStatuses[i].ExitCode = 0
-					}
-				}
-			},
-			actions: podActions{
-				KillPod:           true,
-				SandboxID:         baseStatus.SandboxStatuses[0].Id,
-				ContainersToKill:  getKillMap(basePod, baseStatus, []int{}),
-				ContainersToStart: []int{},
-			},
-		},
-		"Don't restart sidecars if all non-sidecars are terminated": {
-			mutatePodFn: func(pod *v1.Pod) {
-				pod.Spec.RestartPolicy = v1.RestartPolicyOnFailure
-			},
-			mutateStatusFn: func(status *kubecontainer.PodStatus) {
-				for i := range status.ContainerStatuses {
-					status.ContainerStatuses[i].State = kubecontainer.ContainerStateExited
-					if i == 1 {
-						status.ContainerStatuses[i].ExitCode = 1
-					} else {
-						status.ContainerStatuses[i].ExitCode = 0
-					}
-				}
-			},
-			actions: podActions{
-				KillPod:           true,
-				SandboxID:         baseStatus.SandboxStatuses[0].Id,
-				ContainersToKill:  getKillMap(basePod, baseStatus, []int{}),
-				ContainersToStart: []int{},
-			},
-		},
 		"Start sidecar containers before non-sidecars when creating a new pod": {
 			mutateStatusFn: func(status *kubecontainer.PodStatus) {
 				// No container or sandbox exists.


### PR DESCRIPTION
This change turns off the ability to completely kill pods when the
non-sidecars are done. This is useful for cronjobs, where the
non-sidecars finish work and exit, this code previously would clean up
the pod and its resources.

This feature was pulled in from https://github.com/kubernetes/kubernetes/pull/75099.

This is a feature that sounds nice in practice, but its not what we
need. It seems to be a bit buggy since the Pod sandbox can
potentially be deleted and recreated during the liftime of the
Pod. That ain't good.

