### PR TITLE
Allow metrics to be retrieved from CRI with CRI-O

### DIFF
--- a/pkg/kubelet/cadvisor/BUILD
+++ b/pkg/kubelet/cadvisor/BUILD
@@ -51,9 +51,7 @@ go_test(
         "@io_bazel_rules_go//go/platform:linux": [
             "//staging/src/k8s.io/api/core/v1:go_default_library",
             "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
-            "//vendor/github.com/google/cadvisor/container/crio:go_default_library",
             "//vendor/github.com/google/cadvisor/info/v1:go_default_library",
-            "//vendor/github.com/stretchr/testify/assert:go_default_library",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/kubelet/cadvisor/helpers_linux.go
+++ b/pkg/kubelet/cadvisor/helpers_linux.go
@@ -38,13 +38,6 @@ func (i *imageFsInfoProvider) ImageFsInfoLabel() (string, error) {
 	switch i.runtime {
 	case types.DockerContainerRuntime:
 		return cadvisorfs.LabelDockerImages, nil
-	case types.RemoteContainerRuntime:
-		// This is a temporary workaround to get stats for cri-o from cadvisor
-		// and should be removed.
-		// Related to https://github.com/kubernetes/kubernetes/issues/51798
-		if i.runtimeEndpoint == CrioSocket || i.runtimeEndpoint == "unix://"+CrioSocket {
-			return cadvisorfs.LabelCrioImages, nil
-		}
 	}
 	return "", fmt.Errorf("no imagefs label for configured runtime")
 }

--- a/pkg/kubelet/cadvisor/util.go
+++ b/pkg/kubelet/cadvisor/util.go
@@ -27,12 +27,6 @@ import (
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
-const (
-	// Please keep this in sync with the one in:
-	// github.com/google/cadvisor/container/crio/client.go
-	CrioSocket = "/var/run/crio/crio.sock"
-)
-
 func CapacityFromMachineInfo(info *cadvisorapi.MachineInfo) v1.ResourceList {
 	c := v1.ResourceList{
 		v1.ResourceCPU: *resource.NewMilliQuantity(
@@ -66,11 +60,7 @@ func EphemeralStorageCapacityFromFsInfo(info cadvisorapi2.FsInfo) v1.ResourceLis
 // CRI integrations should get container metrics via CRI. Docker
 // uses the built-in cadvisor to gather such metrics on Linux for
 // historical reasons.
-// cri-o relies on cadvisor as a temporary workaround. The code should
-// be removed. Related issue:
-// https://github.com/kubernetes/kubernetes/issues/51798
 // UsingLegacyCadvisorStats returns true if container stats are provided by cadvisor instead of through the CRI
 func UsingLegacyCadvisorStats(runtime, runtimeEndpoint string) bool {
-	return (runtime == kubetypes.DockerContainerRuntime && goruntime.GOOS == "linux") ||
-		runtimeEndpoint == CrioSocket || runtimeEndpoint == "unix://"+CrioSocket
+	return (runtime == kubetypes.DockerContainerRuntime && goruntime.GOOS == "linux")
 }

--- a/pkg/kubelet/cadvisor/util_test.go
+++ b/pkg/kubelet/cadvisor/util_test.go
@@ -22,9 +22,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/cadvisor/container/crio"
 	info "github.com/google/cadvisor/info/v1"
-	"github.com/stretchr/testify/assert"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -50,8 +48,4 @@ func TestCapacityFromMachineInfoWithHugePagesEnable(t *testing.T) {
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("when set hugepages true, got resource list %v, want %v", actual, expected)
 	}
-}
-
-func TestCrioSocket(t *testing.T) {
-	assert.EqualValues(t, CrioSocket, crio.CrioSocket, "CrioSocket in this package must equal the one in github.com/google/cadvisor/container/crio/client.go")
 }


### PR DESCRIPTION
CRI-O properly implements the CRI interface, and therefore it is
capable of returning the container stats if being asked for.

There is no reason to keep CRI-O as a special use case that has to
be run with the legacy mode making kubelet using cadvisor on each
container.

This patch removes the hardcoded assumptions that CRI-O has cannot
handle to return containers stats through CRI.

Fixes #73750

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
