### PR TITLE
do not consider exited containers when calculating nanocores

### DIFF
--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -734,9 +734,8 @@ func removeTerminatedPods(pods []*runtimeapi.PodSandbox) []*runtimeapi.PodSandbo
 	return result
 }
 
-// removeTerminatedContainers returns containers with terminated ones.
-// It only removes a terminated container when there is a running instance
-// of the container.
+// removeTerminatedContainers removes all terminated containers since they should
+// not be used for usage calculations.
 func removeTerminatedContainers(containers []*runtimeapi.Container) []*runtimeapi.Container {
 	containerMap := make(map[containerID][]*runtimeapi.Container)
 	// Sort order by create time
@@ -755,17 +754,15 @@ func removeTerminatedContainers(containers []*runtimeapi.Container) []*runtimeap
 	for _, refs := range containerMap {
 		if len(refs) == 1 {
 			result = append(result, refs[0])
+			if refs[0].State == runtimeapi.ContainerState_CONTAINER_RUNNING {
+				result = append(result, refs[0])
+			}
 			continue
 		}
-		found := false
 		for i := 0; i < len(refs); i++ {
 			if refs[i].State == runtimeapi.ContainerState_CONTAINER_RUNNING {
-				found = true
 				result = append(result, refs[i])
 			}
-		}
-		if !found {
-			result = append(result, refs[len(refs)-1])
 		}
 	}
 	return result

--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -649,7 +649,7 @@ func (p *criStatsProvider) getAndUpdateContainerUsageNanoCores(stats *runtimeapi
 		defer p.mutex.Unlock()
 
 		cached, ok := p.cpuUsageCache[id]
-		if !ok || cached.stats.UsageCoreNanoSeconds == nil {
+		if !ok || cached.stats.UsageCoreNanoSeconds == nil || stats.Cpu.UsageCoreNanoSeconds < cached.stats.UsageCoreNanoSeconds {
 			// Cannot compute the usage now, but update the cached stats anyway
 			p.cpuUsageCache[id] = &cpuUsageRecord{stats: stats.Cpu, usageNanoCores: nil}
 			return nil, nil

--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -649,7 +649,7 @@ func (p *criStatsProvider) getAndUpdateContainerUsageNanoCores(stats *runtimeapi
 		defer p.mutex.Unlock()
 
 		cached, ok := p.cpuUsageCache[id]
-		if !ok || cached.stats.UsageCoreNanoSeconds == nil || stats.Cpu.UsageCoreNanoSeconds < cached.stats.UsageCoreNanoSeconds {
+		if !ok || cached.stats.UsageCoreNanoSeconds == nil || stats.Cpu.UsageCoreNanoSeconds.Value < cached.stats.UsageCoreNanoSeconds.Value {
 			// Cannot compute the usage now, but update the cached stats anyway
 			p.cpuUsageCache[id] = &cpuUsageRecord{stats: stats.Cpu, usageNanoCores: nil}
 			return nil, nil

--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -752,13 +752,6 @@ func removeTerminatedContainers(containers []*runtimeapi.Container) []*runtimeap
 
 	result := make([]*runtimeapi.Container, 0)
 	for _, refs := range containerMap {
-		if len(refs) == 1 {
-			result = append(result, refs[0])
-			if refs[0].State == runtimeapi.ContainerState_CONTAINER_RUNNING {
-				result = append(result, refs[0])
-			}
-			continue
-		}
 		for i := 0; i < len(refs); i++ {
 			if refs[i].State == runtimeapi.ContainerState_CONTAINER_RUNNING {
 				result = append(result, refs[i])


### PR DESCRIPTION
`cri_stats_provider` currently only removes terminated containers if there is another container with its id currently running. It appears this is legacy behavior introduced in the cadvisor provider in order to patch an old bug where cgroups were not getting removed on container deletion, causing cadvisor to send duplicate stats for a container. As far as I can tell, the main purpose of `removeTerminatedContainers()` is for deduplication. However, it does not make a lot of sense to consider exited containers when calculating resource usage in the first place, and I could not find a good justification in the open source commit history for why terminated containers should be considered in the calculation, so in my opinion this behavior should be safe to remove. 

The bug we were seeing happened when a container exited and was replaced by another within a pod, notably during CrashLoopBackoff situations. The cri stats provider would look at the old container which was reporting zero usage since it was no longer running, but still reporting a nonzero timestamp, and try to do some math with the nonzero stats coming from the new container, which resulted in a nonsensical number.

By removing all exited containers before calculating usage we avoid this behavior. Calculation of cpu utilization remains accurate because the containers we are removing all have zero usage.