### PR TITLE
Drop container backoff from 5 to 2.5 minute max.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -128,7 +128,7 @@ const (
 	ContainerLogsDir = "/var/log/containers"
 
 	// MaxContainerBackOff is the max backoff period, exported for the e2e test
-	MaxContainerBackOff = 300 * time.Second
+	MaxContainerBackOff = 150 * time.Second // Lyft custom.
 
 	// Capacity of the channel for storing pods to kill. A small number should
 	// suffice because a goroutine is dedicated to check the channel and does


### PR DESCRIPTION
This PR reduces the max ImagePullBackOff and CrashLoopBackOff backoff time. IE, one of those backoffs will wait at most 2.5 mins before retrying.

It may be a bit more work, but it would be possible to change the maximum backoff time independently.