### PR TITLE
Remove CronJob "100 missed start times" error

### DIFF
--- a/pkg/controller/cronjob/cronjob_controller.go
+++ b/pkg/controller/cronjob/cronjob_controller.go
@@ -290,7 +290,7 @@ func syncOne(sj *batchv1beta1.CronJob, js []batchv1.Job, now time.Time, jc jobCo
 		klog.V(4).Infof("Multiple unmet start times for %s so only starting last one", nameForLog)
 	}
 
-	scheduledTime := times[len(times)-1]
+	scheduledTime := times[0]
 	tooLate := false
 	if sj.Spec.StartingDeadlineSeconds != nil {
 		tooLate = scheduledTime.Add(time.Second * time.Duration(*sj.Spec.StartingDeadlineSeconds)).Before(now)

--- a/pkg/controller/cronjob/cronjob_controller_test.go
+++ b/pkg/controller/cronjob/cronjob_controller_test.go
@@ -231,14 +231,14 @@ func TestSyncOne_RunOrNot(t *testing.T) {
 		"still active, is time, past deadline":     {A, F, onTheHour, shortDead, T, T, justAfterTheHour(), F, F, 1, 0},
 		"still active, is time, not past deadline": {A, F, onTheHour, longDead, T, T, justAfterTheHour(), T, F, 2, 0},
 
-		// Controller should fail to schedule these, as there are too many missed starting times
-		// and either no deadline or a too long deadline.
-		"prev ran but done, long overdue, not past deadline, A": {A, F, onTheHour, longDead, T, F, weekAfterTheHour(), F, F, 0, 1},
-		"prev ran but done, long overdue, not past deadline, R": {R, F, onTheHour, longDead, T, F, weekAfterTheHour(), F, F, 0, 1},
-		"prev ran but done, long overdue, not past deadline, F": {f, F, onTheHour, longDead, T, F, weekAfterTheHour(), F, F, 0, 1},
-		"prev ran but done, long overdue, no deadline, A":       {A, F, onTheHour, noDead, T, F, weekAfterTheHour(), F, F, 0, 1},
-		"prev ran but done, long overdue, no deadline, R":       {R, F, onTheHour, noDead, T, F, weekAfterTheHour(), F, F, 0, 1},
-		"prev ran but done, long overdue, no deadline, F":       {f, F, onTheHour, noDead, T, F, weekAfterTheHour(), F, F, 0, 1},
+		// Controller should be able to schedule these,
+		// regardless of many missed start times.
+		"prev ran but done, long overdue, not past deadline, A": {A, F, onTheHour, longDead, T, F, weekAfterTheHour(), T, F, 1, 0},
+		"prev ran but done, long overdue, not past deadline, R": {R, F, onTheHour, longDead, T, F, weekAfterTheHour(), T, F, 1, 0},
+		"prev ran but done, long overdue, not past deadline, F": {f, F, onTheHour, longDead, T, F, weekAfterTheHour(), T, F, 1, 0},
+		"prev ran but done, long overdue, no deadline, A":       {A, F, onTheHour, noDead, T, F, weekAfterTheHour(), T, F, 1, 0},
+		"prev ran but done, long overdue, no deadline, R":       {R, F, onTheHour, noDead, T, F, weekAfterTheHour(), T, F, 1, 0},
+		"prev ran but done, long overdue, no deadline, F":       {f, F, onTheHour, noDead, T, F, weekAfterTheHour(), T, F, 1, 0},
 
 		"prev ran but done, long overdue, past medium deadline, A": {A, F, onTheHour, mediumDead, T, F, weekAfterTheHour(), T, F, 1, 0},
 		"prev ran but done, long overdue, past short deadline, A":  {A, F, onTheHour, shortDead, T, F, weekAfterTheHour(), T, F, 1, 0},
@@ -354,7 +354,9 @@ func TestSyncOne_RunOrNot(t *testing.T) {
 			t.Errorf("%s: expected %d warnings, actually %v", name, tc.expectedWarnings, numWarnings)
 		}
 
-		if tc.expectActive != len(sjc.Updates[expectUpdates-1].Status.Active) {
+		if len(sjc.Updates) != expectUpdates {
+			t.Errorf("%s: expected %d updates, got %d", name, expectUpdates, len(sjc.Updates))
+		} else if tc.expectActive != len(sjc.Updates[expectUpdates-1].Status.Active) {
 			t.Errorf("%s: expected Active size %d, got %d", name, tc.expectActive, len(sjc.Updates[expectUpdates-1].Status.Active))
 		}
 	}


### PR DESCRIPTION
The CronJob controller emits an error when 100 start times have been missed, in some cases (most notably, when there is no starting deadline or a long starting deadline).

This is a consequence of the controller's author working around the featureset in an external module. The module has a function to list CronJob schedule times in the future, but not in the past. The author iterates from <some potentially distant time> to the present, in order to find the most recent missed start time. The author added this 100 minute due to the small-but-nontrivial cost of performing this many times.

I have added a function to get the _previous_ CronJob schedule time, and modified checks around this.

Unit tests pass - I have not run integration/e2e tests.