### PR TITLE
Remove CronJob "100 missed start times" error (binary search approach)

### DIFF
--- a/pkg/controller/cronjob/cronjob_controller_test.go
+++ b/pkg/controller/cronjob/cronjob_controller_test.go
@@ -231,14 +231,12 @@ func TestSyncOne_RunOrNot(t *testing.T) {
 		"still active, is time, past deadline":     {A, F, onTheHour, shortDead, T, T, justAfterTheHour(), F, F, 1, 0},
 		"still active, is time, not past deadline": {A, F, onTheHour, longDead, T, T, justAfterTheHour(), T, F, 2, 0},
 
-		// Controller should fail to schedule these, as there are too many missed starting times
-		// and either no deadline or a too long deadline.
-		"prev ran but done, long overdue, not past deadline, A": {A, F, onTheHour, longDead, T, F, weekAfterTheHour(), F, F, 0, 1},
-		"prev ran but done, long overdue, not past deadline, R": {R, F, onTheHour, longDead, T, F, weekAfterTheHour(), F, F, 0, 1},
-		"prev ran but done, long overdue, not past deadline, F": {f, F, onTheHour, longDead, T, F, weekAfterTheHour(), F, F, 0, 1},
-		"prev ran but done, long overdue, no deadline, A":       {A, F, onTheHour, noDead, T, F, weekAfterTheHour(), F, F, 0, 1},
-		"prev ran but done, long overdue, no deadline, R":       {R, F, onTheHour, noDead, T, F, weekAfterTheHour(), F, F, 0, 1},
-		"prev ran but done, long overdue, no deadline, F":       {f, F, onTheHour, noDead, T, F, weekAfterTheHour(), F, F, 0, 1},
+		"prev ran but done, long overdue, not past deadline, A": {A, F, onTheHour, longDead, T, F, weekAfterTheHour(), T, F, 1, 0},
+		"prev ran but done, long overdue, not past deadline, R": {R, F, onTheHour, longDead, T, F, weekAfterTheHour(), T, F, 1, 0},
+		"prev ran but done, long overdue, not past deadline, F": {f, F, onTheHour, longDead, T, F, weekAfterTheHour(), T, F, 1, 0},
+		"prev ran but done, long overdue, no deadline, A":       {A, F, onTheHour, noDead, T, F, weekAfterTheHour(), T, F, 1, 0},
+		"prev ran but done, long overdue, no deadline, R":       {R, F, onTheHour, noDead, T, F, weekAfterTheHour(), T, F, 1, 0},
+		"prev ran but done, long overdue, no deadline, F":       {f, F, onTheHour, noDead, T, F, weekAfterTheHour(), T, F, 1, 0},
 
 		"prev ran but done, long overdue, past medium deadline, A": {A, F, onTheHour, mediumDead, T, F, weekAfterTheHour(), T, F, 1, 0},
 		"prev ran but done, long overdue, past short deadline, A":  {A, F, onTheHour, shortDead, T, F, weekAfterTheHour(), T, F, 1, 0},

--- a/pkg/controller/cronjob/utils.go
+++ b/pkg/controller/cronjob/utils.go
@@ -91,7 +91,7 @@ func groupJobsByParent(js []batchv1.Job) map[types.UID][]batchv1.Job {
 // If there are too many (>100) unstarted times, just give up and return an empty slice.
 // If there were missed times prior to the last known start time, then those are not returned.
 func getRecentUnmetScheduleTimes(sj batchv1beta1.CronJob, now time.Time) ([]time.Time, error) {
-	starts := []time.Time{}
+	starts := make([]time.Time, 0)
 	sched, err := cron.ParseStandard(sj.Spec.Schedule)
 	if err != nil {
 		return starts, fmt.Errorf("Unparseable schedule: %s : %s", sj.Spec.Schedule, err)
@@ -121,31 +121,85 @@ func getRecentUnmetScheduleTimes(sj batchv1beta1.CronJob, now time.Time) ([]time
 		return []time.Time{}, nil
 	}
 
-	for t := sched.Next(earliestTime); !t.After(now); t = sched.Next(t) {
-		starts = append(starts, t)
-		// An object might miss several starts. For example, if
-		// controller gets wedged on friday at 5:01pm when everyone has
-		// gone home, and someone comes in on tuesday AM and discovers
-		// the problem and restarts the controller, then all the hourly
-		// jobs, more than 80 of them for one hourly scheduledJob, should
-		// all start running with no further intervention (if the scheduledJob
-		// allows concurrency and late starts).
-		//
-		// However, if there is a bug somewhere, or incorrect clock
-		// on controller's server or apiservers (for setting creationTimestamp)
-		// then there could be so many missed start times (it could be off
-		// by decades or more), that it would eat up all the CPU and memory
-		// of this controller. In that case, we want to not try to list
-		// all the missed start times.
-		//
-		// I've somewhat arbitrarily picked 100, as more than 80,
-		// but less than "lots".
-		if len(starts) > 100 {
-			// We can't get the most recent times so just return an empty slice
-			return []time.Time{}, fmt.Errorf("Too many missed start time (> 100). Set or decrease .spec.startingDeadlineSeconds or check clock skew.")
+	// For the sake of easy patching, try to "hide" getLatestMissedSchedule
+	latestTime, missedTimes := getLatestMissedSchedule(earliestTime, now, sched)
+	for i := 0; i < missedTimes; i++ {
+		starts = append(starts, latestTime) // This technically breaks the function signature, but the actual consumer only cares about starts[0] and len(starts).
+	}
+
+	return starts, nil
+}
+
+// getLatestMissedSchedule returns the latest start time in the time window (inclusive), and the number of schedules in the time window (capped at 2).
+// The number of missed start times conveys "none, one, multiple".
+func getLatestMissedSchedule(startWindow time.Time, endWindow time.Time, schedule cron.Schedule) (time.Time, int) {
+	nextSchedule := schedule.Next(startWindow)
+
+	// If no schedules in window, return.
+	if nextSchedule.After(endWindow) {
+		return time.Time{}, 0
+
+		// There is (at least one) schedule in the window. See if there are more later ones.
+	} else {
+		latestSchedule, found := getLatestMissedScheduleBinarySearch(nextSchedule, endWindow, schedule)
+		if found && latestSchedule != nextSchedule {
+			return latestSchedule, 2 // We missed at least 2 schedules. Return the latest.
+		} else {
+			return nextSchedule, 1
 		}
 	}
-	return starts, nil
+}
+
+// LatestScheduleTime, foundSchedule
+// getLatestMissedSchedule returns the latest start time in the specified time window (inclusive). It also returns true if a start time was found, false otherwise
+// It uses a binary search with the cron.Next function, to avoid stepping through every cron schedule.
+// This is less efficient than if cron.Previous existed, but is arguably simpler to review and test than a custom Previous function.
+func getLatestMissedScheduleBinarySearch(startWindow time.Time, endWindow time.Time, schedule cron.Schedule) (time.Time, bool) {
+	// Crons can't schedule in lower granularity than a minute.
+	// If we are looking at a time window less than a minute, there is "room" for at most 1 schedule, and we can skip the binary search.
+	minimumTimeUnit := time.Minute
+	if endWindow.Sub(startWindow) < minimumTimeUnit {
+		nextStart := schedule.Next(startWindow)
+		if !nextStart.After(endWindow) {
+			return nextStart, true
+		} else {
+			return time.Time{}, false
+		}
+	}
+
+	// Break the window into 2 halves for a binary search.
+	midway := startWindow.Add(endWindow.Sub(startWindow) / 2)
+
+	// Check the second half of the window for a start time.
+	// If there is a start time within this window, we can safely ignore the first half of the window.
+	nextScheduleAfterMidway := schedule.Next(midway)
+	if !nextScheduleAfterMidway.After(endWindow) {
+		latestFound, found := getLatestMissedScheduleBinarySearch(nextScheduleAfterMidway, endWindow, schedule) // Check a sub-window between the found schedule and the end of the window.
+		if found {
+			return latestFound, true
+		} else {
+			return nextScheduleAfterMidway, true
+		}
+
+		// If there was no start time in the second half of the window, we need to check the first half of the window.
+	} else {
+
+		nextScheduleInWindow := schedule.Next(startWindow)
+		if !nextScheduleInWindow.After(midway) { // Latest start time is in first half. There's no start time in the second half.
+			latestFound, found := getLatestMissedScheduleBinarySearch(nextScheduleInWindow, midway, schedule) // Check the first half.
+			if found {
+				return latestFound, true
+			} else {
+				return nextScheduleInWindow, true
+			}
+
+			// If there was no schedule time in the first half of the window either,
+			// then there is no missed schedule.
+		} else {
+			return time.Time{}, false
+		}
+
+	}
 }
 
 // getJobFromTemplate makes a Job from a CronJob

--- a/pkg/controller/cronjob/utils_test.go
+++ b/pkg/controller/cronjob/utils_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/robfig/cron"
+
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	"k8s.io/api/core/v1"
@@ -330,7 +332,7 @@ func TestGetRecentUnmetScheduleTimes(t *testing.T) {
 		if len(times) != 1 {
 			t.Errorf("expected 1 start times, got: %v", times)
 		} else if !times[0].Equal(T2) {
-			t.Errorf("expected: %v, got: %v", T1, times[0])
+			t.Errorf("expected: %v, got: %v", T2, times[0])
 		}
 	}
 	{
@@ -346,11 +348,8 @@ func TestGetRecentUnmetScheduleTimes(t *testing.T) {
 		if len(times) != 2 {
 			t.Errorf("expected 2 start times, got: %v", times)
 		} else {
-			if !times[0].Equal(T1) {
-				t.Errorf("expected: %v, got: %v", T1, times[0])
-			}
-			if !times[1].Equal(T2) {
-				t.Errorf("expected: %v, got: %v", T2, times[1])
+			if !times[len(times)-1].Equal(T2) {
+				t.Errorf("expected: %v, got: %v", T2, times[len(times)-1])
 			}
 		}
 	}
@@ -359,9 +358,16 @@ func TestGetRecentUnmetScheduleTimes(t *testing.T) {
 		sj.ObjectMeta.CreationTimestamp = metav1.Time{Time: T1.Add(-2 * time.Hour)}
 		sj.Status.LastScheduleTime = &metav1.Time{Time: T1.Add(-1 * time.Hour)}
 		now := T2.Add(10 * 24 * time.Hour)
-		_, err := getRecentUnmetScheduleTimes(sj, now)
-		if err == nil {
-			t.Errorf("expected an error")
+		times, err := getRecentUnmetScheduleTimes(sj, now)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if len(times) != 2 {
+			t.Errorf("expected 2 start times, got: %v", times)
+		} else {
+			if !times[len(times)-1].Equal(now) {
+				t.Errorf("expected: %v, got: %v", now, times[len(times)-1])
+			}
 		}
 	}
 	{
@@ -438,6 +444,160 @@ func TestByJobStartTime(t *testing.T) {
 		sort.Sort(byJobStartTime(testCase.input))
 		if !reflect.DeepEqual(testCase.input, testCase.expected) {
 			t.Errorf("case: '%s', jobs not sorted as expected", testCase.name)
+		}
+	}
+}
+
+func Test_getLatestMissedSchedule(t *testing.T) {
+	startTime, err := time.Parse(time.RFC3339, "2016-05-19T10:00:00Z")
+	if err != nil {
+		panic("test setup error")
+	}
+
+	hourly, err := cron.ParseStandard("0 * * * *")
+	if err != nil {
+		t.Errorf("couldn't parse schedule")
+	}
+	minutely, err := cron.ParseStandard("* * * * *")
+	if err != nil {
+		t.Errorf("couldn't parse schedule")
+	}
+
+	cases := []struct {
+		desc        string
+		end         time.Time
+		schedule    cron.Schedule
+		expectFound bool
+		expect      time.Time
+	}{
+		{
+			desc:        "basic case",
+			end:         weekAfterTheHour(),
+			schedule:    hourly,
+			expectFound: true,
+			expect:      weekAfterTheHour(),
+		},
+		{
+			desc:        "no time",
+			end:         startTime,
+			schedule:    minutely,
+			expectFound: false,
+		},
+		{
+			desc:        "not enough time",
+			end:         startTime.Add(time.Second * 59),
+			schedule:    minutely,
+			expectFound: false,
+		},
+		{
+			desc:        "just enough time",
+			end:         startTime.Add(time.Minute),
+			schedule:    minutely,
+			expectFound: true,
+			expect:      startTime.Add(time.Minute),
+		},
+	}
+
+	for _, c := range cases {
+		actual, numberMissed := getLatestMissedSchedule(startTime, c.end, c.schedule)
+		if (numberMissed > 0) != c.expectFound {
+			t.Errorf("For case '%s' at %v, expected %v, got %v", c.schedule, c.end, c.expect, actual)
+		}
+		if actual != c.expect {
+			t.Errorf("%v", actual)
+		}
+	}
+}
+
+func Test_getLatestMissedScheduleBinarySearch(t *testing.T) {
+	startTime, err := time.Parse(time.RFC3339, "2016-05-19T10:00:00Z")
+	if err != nil {
+		panic("test setup error")
+	}
+
+	elevenOnTheHour, err := cron.ParseStandard("0 10,11 * * *")
+	if err != nil {
+		t.Errorf("couldn't parse schedule")
+	}
+	hourly, err := cron.ParseStandard("0 * * * *")
+	if err != nil {
+		t.Errorf("couldn't parse schedule")
+	}
+	minutely, err := cron.ParseStandard("* * * * *")
+	if err != nil {
+		t.Errorf("couldn't parse schedule")
+	}
+
+	cases := []struct {
+		desc        string
+		end         time.Time
+		schedule    cron.Schedule
+		expectFound bool
+		expect      time.Time
+	}{
+		{
+			desc:        "basic case",
+			end:         weekAfterTheHour(),
+			schedule:    hourly,
+			expectFound: true,
+			expect:      weekAfterTheHour(),
+		},
+		{
+			desc:        "long case",
+			end:         startTime.Add(time.Hour*24*500 - time.Second), // 500 days later, minus 1 second.
+			schedule:    minutely,
+			expectFound: true,
+			expect:      startTime.Add(time.Hour*24*500 - time.Minute), // 500 days later, minus 1 minute.
+		},
+		{
+			desc:        "no time",
+			end:         startTime,
+			schedule:    minutely,
+			expectFound: false,
+		},
+		{
+			desc:        "not enough time",
+			end:         startTime.Add(time.Second * 59),
+			schedule:    minutely,
+			expectFound: false,
+		},
+		{
+			desc:        "just enough time",
+			end:         startTime.Add(time.Minute),
+			schedule:    minutely,
+			expectFound: true,
+			expect:      startTime.Add(time.Minute),
+		},
+		{
+			desc:        "bounds check on midway",
+			end:         startTime.Add(time.Hour*2),
+			schedule:    elevenOnTheHour,
+			expectFound: true,
+			expect:      startTime.Add(time.Hour),
+		},
+		{
+			desc:        "result just before midway",
+			end:         startTime.Add(time.Hour*2 + time.Minute), // Midway is 30s after the schedule time.
+			schedule:    elevenOnTheHour,
+			expectFound: true,
+			expect:      startTime.Add(time.Hour),
+		},
+		{
+			desc:        "result just after midway",
+			end:         startTime.Add(time.Hour*2 - time.Minute), // Midway is 30s before the schedule time.
+			schedule:    elevenOnTheHour,
+			expectFound: true,
+			expect:      startTime.Add(time.Hour),
+		},
+	}
+
+	for _, c := range cases {
+		actual, found := getLatestMissedScheduleBinarySearch(startTime, c.end, c.schedule)
+		if found != c.expectFound {
+			t.Errorf("For case '%s' at %v, expected %v, got %v", c.schedule, c.end, c.expect, actual)
+		}
+		if actual != c.expect {
+			t.Errorf("%v", actual)
 		}
 	}
 }


### PR DESCRIPTION
This PR is a less efficient but simpler alternative to #12 

As the robfig/cron module only exposes a Next() function for schedules, this PR uses a binary search, rather than brute force, to traverse the schedule window.

The flow of `getLatestMissedScheduleBinarySearch` is roughly this:
1. Check the second half of the window for the earliest schedule. If there is one, recurse.
2. Check the first half of the window for the earliest schedule. If there is one, recurse.
3. If neither window contained a valid schedule, there are no missed start times.
The answer is the latest missed start time that is found.

`getRecentUnmetScheduleTimes()` is still the interface for performing this check (in the interest of easy patching for the next few releases). `getRecentUnmetScheduleTimes()` retains the required properties of its return types - specifically, `results[-1]is the most result missed start time, and `0 <= len(results) <= 2` (used for events/logging). The results no longer contain a precise count, or other start times prior to the most recent one.