### PR TITLE
create scheduling_decision metrics

### DIFF
--- a/pkg/controller/cronjob/cronjob_controller.go
+++ b/pkg/controller/cronjob/cronjob_controller.go
@@ -38,7 +38,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -85,6 +85,8 @@ func NewCronJobController(kubeClient clientset.Interface) (*CronJobController, e
 		podControl: &realPodControl{KubeClient: kubeClient},
 		recorder:   eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "cronjob-controller"}),
 	}
+
+	registerMetrics()
 
 	return jm, nil
 }
@@ -297,6 +299,7 @@ func syncOne(sj *batchv1beta1.CronJob, js []batchv1.Job, now time.Time, jc jobCo
 	}
 	if tooLate {
 		klog.V(4).Infof("Missed starting window for %s", nameForLog)
+		schedulingDecisionSkip.WithLabelValues(sj.Namespace, sj.Name).Inc()
 		recorder.Eventf(sj, v1.EventTypeWarning, "MissSchedule", "Missed scheduled time to start a job: %s", scheduledTime.Format(time.RFC1123Z))
 		// TODO: Since we don't set LastScheduleTime when not scheduling, we are going to keep noticing
 		// the miss every cycle.  In order to avoid sending multiple events, and to avoid processing
@@ -318,6 +321,7 @@ func syncOne(sj *batchv1beta1.CronJob, js []batchv1.Job, now time.Time, jc jobCo
 		// With replace, we could use a name that is deterministic per execution time.
 		// But that would mean that you could not inspect prior successes or failures of Forbid jobs.
 		klog.V(4).Infof("Not starting job for %s because of prior execution still running and concurrency policy is Forbid", nameForLog)
+		schedulingDecisionSkip.WithLabelValues(sj.Namespace, sj.Name).Inc()
 		return
 	}
 	if sj.Spec.ConcurrencyPolicy == batchv1beta1.ReplaceConcurrent {
@@ -326,10 +330,12 @@ func syncOne(sj *batchv1beta1.CronJob, js []batchv1.Job, now time.Time, jc jobCo
 
 			job, err := jc.GetJob(j.Namespace, j.Name)
 			if err != nil {
+				schedulingDecisionSkip.WithLabelValues(sj.Namespace, sj.Name).Inc()
 				recorder.Eventf(sj, v1.EventTypeWarning, "FailedGet", "Get job: %v", err)
 				return
 			}
 			if !deleteJob(sj, job, jc, recorder) {
+				schedulingDecisionSkip.WithLabelValues(sj.Namespace, sj.Name).Inc()
 				return
 			}
 		}
@@ -338,9 +344,11 @@ func syncOne(sj *batchv1beta1.CronJob, js []batchv1.Job, now time.Time, jc jobCo
 	jobReq, err := getJobFromTemplate(sj, scheduledTime)
 	if err != nil {
 		klog.Errorf("Unable to make Job from template in %s: %v", nameForLog, err)
+		schedulingDecisionSkip.WithLabelValues(sj.Namespace, sj.Name).Inc()
 		return
 	}
 	jobResp, err := jc.CreateJob(sj.Namespace, jobReq)
+	schedulingDecisionInvoke.WithLabelValues(sj.Namespace, sj.Name).Inc()
 	if err != nil {
 		recorder.Eventf(sj, v1.EventTypeWarning, "FailedCreate", "Error creating job: %v", err)
 		return

--- a/pkg/controller/cronjob/metrics.go
+++ b/pkg/controller/cronjob/metrics.go
@@ -10,6 +10,13 @@ const (
 	cronjobSubsystem = "cronjob_controller"
 	cronNameKey      = "cronjob"
 	namespaceKey     = "namespace"
+	skipReasonKey    = "reason"
+)
+
+const (
+	skipReasonConcurrencyPolicy = "concurrencyPolicy"
+	skipReasonMissedDeadline    = "missedDeadline"
+	skipReasonError             = "error"
 )
 
 var schedulingDecisionInvoke = prometheus.NewCounterVec(
@@ -26,7 +33,7 @@ var schedulingDecisionSkip = prometheus.NewCounterVec(
 		Name:      "scheduling_decision_skip",
 		Help:      "Counter that increments when the cronjob controller decides to skip a CronJob invocation",
 	},
-	[]string{namespaceKey, cronNameKey})
+	[]string{namespaceKey, cronNameKey, skipReasonKey})
 
 var registerOnce sync.Once
 

--- a/pkg/controller/cronjob/metrics.go
+++ b/pkg/controller/cronjob/metrics.go
@@ -1,0 +1,38 @@
+package cronjob
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	cronjobSubsystem = "cronjob_controller"
+	cronNameKey      = "cronjob"
+	namespaceKey     = "namespace"
+)
+
+var schedulingDecisionInvoke = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Subsystem: cronjobSubsystem,
+		Name:      "scheduling_decision_invoke",
+		Help:      "Counter that increments when the cronjob controller decides to invoke a CronJob",
+	},
+	[]string{namespaceKey, cronNameKey})
+
+var schedulingDecisionSkip = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Subsystem: cronjobSubsystem,
+		Name:      "scheduling_decision_skip",
+		Help:      "Counter that increments when the cronjob controller decides to skip a CronJob invocation",
+	},
+	[]string{namespaceKey, cronNameKey})
+
+var registerOnce sync.Once
+
+func registerMetrics() {
+	registerOnce.Do(func() {
+		prometheus.MustRegister(schedulingDecisionInvoke)
+		prometheus.MustRegister(schedulingDecisionSkip)
+	})
+}


### PR DESCRIPTION
This commit introduces 2 new metrics:

`scheduling_decision_invoke` is a counter per CronJob, per Namespace,
that is incremented when the cronjob_controller decides to invoke a
CronJob.

`scheduling_decision_skip` is a counter per CronJob, per Namespace, that
is incremented when the cronjob_controller sees that a CronJob has unmet
schedule times, but chooses to still skip invoking the CronJob. This can
happen because:
1. the controller missed the deadline to invoke the CronJob
2. ConcurrencyPolicy is Forbid, and a previous job is still running
3. ConcurrencyPolicy is Replace, and there's an error in trying to
replace the currently running job (such as failed deletion)
4. The controller fails to instantiate a Job spec from the CronJob
template

Note: Kubernetes 1.14 does not include k8s.io/component-base/metrics.
When porting this to 1.16, we'll need to convert to using
k8s.io/component-base/metrics
