### PR TITLE
add metrics for monitoring syncAll and syncOne wall time

### DIFF
--- a/pkg/controller/cronjob/metrics.go
+++ b/pkg/controller/cronjob/metrics.go
@@ -2,6 +2,7 @@ package cronjob
 
 import (
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -49,6 +50,48 @@ var jobFailed = prometheus.NewCounterVec(
 		Help:      "Counter that increments when the cronjob controller detects a child Job has completed with failure",
 	}, []string{namespaceKey, cronNameKey})
 
+var syncOneWallTimeGauge = prometheus.NewGauge(
+	prometheus.GaugeOpts{
+		Subsystem: cronjobSubsystem,
+		Name:      "sync_one_wall_time_gauge_seconds",
+		Help:      "Gauge that observes time in seconds it takes the syncOne function to run. Long wall times indicate potential kube client rate limiting",
+	})
+
+var syncOneWallTimeHistogram = prometheus.NewHistogram(
+	prometheus.HistogramOpts{
+		Subsystem: cronjobSubsystem,
+		Name:      "sync_one_wall_time_histogram_seconds",
+		Help:      "Histogram that observes time in seconds it takes the syncOne function to run. Long wall times indicate potential kube client rate limiting",
+		// Buckets range from 1 microsecond to 1 second by factors of 10
+		Buckets: prometheus.ExponentialBuckets(1e-6, 10, 7),
+	})
+
+var syncAllWallTimeGauge = prometheus.NewGauge(
+	prometheus.GaugeOpts{
+		Subsystem: cronjobSubsystem,
+		Name:      "sync_all_wall_time_gauge_seconds",
+		Help:      "Gauge that observes time in seconds it takes the syncAll function to run. Long wall times indicate potential kube client rate limiting",
+	})
+
+var syncAllWallTimeHistogram = prometheus.NewHistogram(
+	prometheus.HistogramOpts{
+		Subsystem: cronjobSubsystem,
+		Name:      "sync_all_wall_time_histogram_seconds",
+		Help:      "Histogram that observes time in seconds it takes the syncAll function to run. Long wall times indicate potential kube client rate limiting",
+		// Buckets at 1, 3, 5, 7,...61 seconds
+		Buckets: prometheus.LinearBuckets(1, 2, 30),
+	})
+
+func observeSyncAllWallTime(d time.Duration) {
+	syncAllWallTimeGauge.Set(d.Seconds())
+	syncAllWallTimeHistogram.Observe(d.Seconds())
+}
+
+func observeSyncOneWallTime(d time.Duration) {
+	syncOneWallTimeGauge.Set(d.Seconds())
+	syncOneWallTimeHistogram.Observe(d.Seconds())
+}
+
 var registerOnce sync.Once
 
 func registerMetrics() {
@@ -57,5 +100,9 @@ func registerMetrics() {
 		prometheus.MustRegister(schedulingDecisionSkip)
 		prometheus.MustRegister(jobSucceeded)
 		prometheus.MustRegister(jobFailed)
+		prometheus.MustRegister(syncOneWallTimeGauge)
+		prometheus.MustRegister(syncOneWallTimeHistogram)
+		prometheus.MustRegister(syncAllWallTimeGauge)
+		prometheus.MustRegister(syncAllWallTimeHistogram)
 	})
 }


### PR DESCRIPTION
This introduces the following metrics:
- `cronjob_controller_sync_one_wall_time_gauge_seconds`
- `cronjob_controller_sync_one_wall_time_histogram_seconds`
- `cronjob_controller_sync_all_wall_time_gauge_seconds`
- `cronjob_controller_sync_all_wall_time_histogram_seconds`

For measuring performance of the `sync` controller loops.

For `cronjob_controller_sync_all_wall_time_histogram_seconds`, this tends to range between 10-30 seconds depending on rate limit settings. I chose linear buckets from 1-60
seconds to get enough granularity.

For `cronjob_controller_sync_one_wall_time_histogram_seconds`, this tends to fluctuate exponentially directly proportional to  kubeclient rate limiting, so that's why I chose exponential
buckets from 1 microsecond to 1 second.

Implementation note: [rate limit saturation isn't actually measured](https://github.com/lyft/kubernetes/blob/f678a63e9a17580b35805021fe4112f0f4cd6271/pkg/util/metrics/util.go#L68-L74) despite the code living in the codebase. Measuring rate limit saturation would help us determine why the CronJobController is slow. Since that's not available, the next best thing is  `syncOne` wall time.
