### PR TITLE
add success/fail metrics per each cronjob invocation

### DIFF
--- a/pkg/controller/cronjob/cronjob_controller.go
+++ b/pkg/controller/cronjob/cronjob_controller.go
@@ -245,6 +245,11 @@ func syncOne(sj *batchv1beta1.CronJob, js []batchv1.Job, now time.Time, jc jobCo
 		} else if found && IsJobFinished(&j) {
 			deleteFromActiveList(sj, j.ObjectMeta.UID)
 			// TODO: event to call out failure vs success.
+			if j.Spec.Completions == nil || j.Status.Succeeded >= *j.Spec.Completions {
+				jobSucceeded.WithLabelValues(sj.Namespace, sj.Name).Inc()
+			} else {
+				jobFailed.WithLabelValues(sj.Namespace, sj.Name).Inc()
+			}
 			recorder.Eventf(sj, v1.EventTypeNormal, "SawCompletedJob", "Saw completed job: %v", j.Name)
 		}
 	}

--- a/pkg/controller/cronjob/metrics.go
+++ b/pkg/controller/cronjob/metrics.go
@@ -35,11 +35,27 @@ var schedulingDecisionSkip = prometheus.NewCounterVec(
 	},
 	[]string{namespaceKey, cronNameKey, skipReasonKey})
 
+var jobSucceeded = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Subsystem: cronjobSubsystem,
+		Name:      "job_succeeded",
+		Help:      "Counter that increments when the cronjob controller detects a child Job has completed with success",
+	}, []string{namespaceKey, cronNameKey})
+
+var jobFailed = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Subsystem: cronjobSubsystem,
+		Name:      "job_failed",
+		Help:      "Counter that increments when the cronjob controller detects a child Job has completed with failure",
+	}, []string{namespaceKey, cronNameKey})
+
 var registerOnce sync.Once
 
 func registerMetrics() {
 	registerOnce.Do(func() {
 		prometheus.MustRegister(schedulingDecisionInvoke)
 		prometheus.MustRegister(schedulingDecisionSkip)
+		prometheus.MustRegister(jobSucceeded)
+		prometheus.MustRegister(jobFailed)
 	})
 }


### PR DESCRIPTION
This PR adds success/fail counters per each cronjob invocation
- `cronjob_controller_job_succeeded{namespace, cronjob}`
- `cronjob_controller_job_succeeded{namespace, cronjob}`
