### PR TITLE
add Job scheduled start time annotation

### DIFF
--- a/pkg/controller/cronjob/utils.go
+++ b/pkg/controller/cronjob/utils.go
@@ -200,7 +200,7 @@ func getLatestMissedScheduleBinarySearch(startWindow time.Time, endWindow time.T
 func getJobFromTemplate(sj *batchv1beta1.CronJob, scheduledTime time.Time) (*batchv1.Job, error) {
 	labels := copyLabels(&sj.Spec.JobTemplate)
 	annotations := copyAnnotations(&sj.Spec.JobTemplate)
-	annotations[jobScheduledTimeAnnotationKey] = metav1.NewTime(scheduledTime).String()
+	annotations[jobScheduledTimeAnnotationKey] = metav1.NewTime(scheduledTime).Format(time.RFC1123Z)
 
 	// We want job names for a given nominal start time to have a deterministic name to avoid the same job being created twice
 	name := fmt.Sprintf("%s-%d", sj.Name, getTimeHash(scheduledTime))

--- a/pkg/controller/cronjob/utils.go
+++ b/pkg/controller/cronjob/utils.go
@@ -31,6 +31,8 @@ import (
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 )
 
+const jobScheduledTimeAnnotationKey = "scheduled-start-time"
+
 // Utilities for dealing with Jobs and CronJobs and time.
 
 func inActiveList(sj batchv1beta1.CronJob, uid types.UID) bool {
@@ -198,6 +200,8 @@ func getLatestMissedScheduleBinarySearch(startWindow time.Time, endWindow time.T
 func getJobFromTemplate(sj *batchv1beta1.CronJob, scheduledTime time.Time) (*batchv1.Job, error) {
 	labels := copyLabels(&sj.Spec.JobTemplate)
 	annotations := copyAnnotations(&sj.Spec.JobTemplate)
+	annotations[jobScheduledTimeAnnotationKey] = metav1.NewTime(scheduledTime).String()
+
 	// We want job names for a given nominal start time to have a deterministic name to avoid the same job being created twice
 	name := fmt.Sprintf("%s-%d", sj.Name, getTimeHash(scheduledTime))
 

--- a/pkg/controller/cronjob/utils_test.go
+++ b/pkg/controller/cronjob/utils_test.go
@@ -77,7 +77,8 @@ func TestGetJobFromTemplate(t *testing.T) {
 	}
 
 	var job *batchv1.Job
-	job, err := getJobFromTemplate(&sj, time.Time{})
+	expectedScheduledTime := time.Date(2020, time.April, 9, 10, 51, 0, 0, time.UTC)
+	job, err := getJobFromTemplate(&sj, expectedScheduledTime)
 	if err != nil {
 		t.Errorf("Did not expect error: %s", err)
 	}
@@ -87,8 +88,18 @@ func TestGetJobFromTemplate(t *testing.T) {
 	if len(job.ObjectMeta.Labels) != 1 {
 		t.Errorf("Wrong number of labels")
 	}
-	if len(job.ObjectMeta.Annotations) != 1 {
+
+	if len(job.ObjectMeta.Annotations) != 2 {
 		t.Errorf("Wrong number of annotations")
+	}
+
+	observedScheduledTimeAnnotation, ok := job.ObjectMeta.Annotations[jobScheduledTimeAnnotationKey]
+	if !ok {
+		t.Errorf("Generated job spec missing %v annotation", jobScheduledTimeAnnotationKey)
+	}
+
+	if observedScheduledTimeAnnotation != expectedScheduledTime.String() {
+		t.Errorf("Wrong %v annotation. Expected %s, got %s.", jobScheduledTimeAnnotationKey, expectedScheduledTime.String(), observedScheduledTimeAnnotation)
 	}
 }
 

--- a/pkg/controller/cronjob/utils_test.go
+++ b/pkg/controller/cronjob/utils_test.go
@@ -98,8 +98,13 @@ func TestGetJobFromTemplate(t *testing.T) {
 		t.Errorf("Generated job spec missing %v annotation", jobScheduledTimeAnnotationKey)
 	}
 
-	if observedScheduledTimeAnnotation != expectedScheduledTime.String() {
-		t.Errorf("Wrong %v annotation. Expected %s, got %s.", jobScheduledTimeAnnotationKey, expectedScheduledTime.String(), observedScheduledTimeAnnotation)
+	parsedTime, err := time.Parse(time.RFC1123Z, observedScheduledTimeAnnotation)
+	if err != nil {
+		t.Errorf("Unexpected error parsing time: %v", err)
+	}
+
+	if parsedTime.Format(time.RFC1123Z) != expectedScheduledTime.Format(time.RFC1123Z) {
+		t.Errorf("Wrong %v annotation. Expected %s, got %s.", jobScheduledTimeAnnotationKey, expectedScheduledTime.Format(time.RFC1123Z), parsedTime.Format(time.RFC1123Z))
 	}
 }
 


### PR DESCRIPTION
This PR adds an annotation to Jobs created by CronJobs that annotates
them with "scheduled-start-time", which is the time that the CronJob is
expected to invoke a Job.

More specifically, if a CronJob is expected to run at 12:00:00, then
this annotation is 12:00:00.

Having this annotation is helpful for measuring start delay - the time
between when a Cron is expected to run, and when it actually does.