### PR TITLE
cronjob: handle invalid/unschedulable dates

### DIFF
--- a/pkg/controller/cronjob/cronjob_controller_test.go
+++ b/pkg/controller/cronjob/cronjob_controller_test.go
@@ -37,8 +37,9 @@ import (
 
 var (
 	// schedule is hourly on the hour
-	onTheHour     = "0 * * * ?"
-	errorSchedule = "obvious error schedule"
+	onTheHour       = "0 * * * ?"
+	errorSchedule   = "obvious error schedule"
+	invalidSchedule = "0 0 31 2 *"
 )
 
 func justBeforeTheHour() time.Time {
@@ -247,6 +248,10 @@ func TestSyncOne_RunOrNot(t *testing.T) {
 
 		"prev ran but done, long overdue, past medium deadline, F": {f, F, onTheHour, mediumDead, T, F, weekAfterTheHour(), T, F, 1, 0},
 		"prev ran but done, long overdue, past short deadline, F":  {f, F, onTheHour, shortDead, T, F, weekAfterTheHour(), T, F, 1, 0},
+
+		"never ran, invalid schedule, A": {A, F, invalidSchedule, longDead, F, F, justBeforeTheHour(), F, F, 0, 1},
+		"never ran, invalid schedule, R": {R, F, invalidSchedule, longDead, F, F, justBeforeTheHour(), F, F, 0, 1},
+		"never ran, invalid schedule, F": {f, F, invalidSchedule, longDead, F, F, justBeforeTheHour(), F, F, 0, 1},
 	}
 	for name, tc := range testCases {
 		name := name

--- a/pkg/controller/cronjob/utils.go
+++ b/pkg/controller/cronjob/utils.go
@@ -124,10 +124,18 @@ func getRecentUnmetScheduleTimes(sj batchv1beta1.CronJob, now time.Time) ([]time
 	return starts, nil
 }
 
+var unschedulableDate = time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
+
 // getLatestMissedSchedule returns the latest start time in the time window (inclusive), and the number of schedules in the time window (capped at 2).
 // The number of missed start times conveys "none, one, multiple".
 func getLatestMissedSchedule(startWindow time.Time, endWindow time.Time, schedule cron.Schedule) (time.Time, int) {
 	nextSchedule := schedule.Next(startWindow)
+
+	// check for invalid case, like "0 0 31 2 *", which would be the
+	// 31st of feb.
+	if nextSchedule == unschedulableDate {
+		return unschedulableDate, 2
+	}
 
 	// If no schedules in window, return.
 	if nextSchedule.After(endWindow) {


### PR DESCRIPTION
There is a case for tricky cron schedules, like 0 0 31 2 *, which
intends to run on Feb 31st. This date does not exist at the moment,
which can cause the earliest-missed-deadline math go into an infinite
loop.

Thankfully, the cron library returns a "zero date" when a next
schedule is not found within 5 years:

https://github.com/robfig/cron/blob/6a8421bcff44c2a9889075724070baaebf8dcd72/spec.go#L87-L88

We rely on seeing this zero date and short-circuit out of our
recursive algorithm.
